### PR TITLE
nextflow: print error when api request fails rather than :boom:

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -69,6 +69,12 @@ workflow.onComplete {
     apiRequest.setRequestProperty("Content-Type", "application/json")
     apiRequest.getOutputStream().write(body.getBytes("UTF-8"))
 
-    def res = new groovy.json.JsonSlurper().parseText(apiRequest.getInputStream().getText())
-    println("Next workflow started at: ${res.workflowRun.webUrl}")
+    def statusCode = apiRequest.getResponseCode()
+    if (statusCode.equals(200)) {
+        def res = new groovy.json.JsonSlurper().parseText(apiRequest.getInputStream().getText())
+        println("Next workflow started at: ${res.workflowRun.webUrl}")
+    } else {
+        println("Failed to start next workflow.")
+        println(apiRequest.getErrorStream().getText())
+    }
 }


### PR DESCRIPTION
![Screenshot 2023-11-01 at 1 31 34 PM](https://github.com/BeakerBio/nf-api-test/assets/19194187/1e499748-7ad0-45e8-94a3-4b02a41b7f01)
